### PR TITLE
Additionalcmdlets

### DIFF
--- a/AzureDevOpsLogging/AzureDevOpsLogging.psd1
+++ b/AzureDevOpsLogging/AzureDevOpsLogging.psd1
@@ -65,7 +65,7 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @('Start-ADOGroup','Stop-ADOGroup','Write-ADOError','Write-ADOWarning')
+    FunctionsToExport = @('Set-ADOVariable','Start-ADOGroup','Stop-ADOGroup','Write-ADOArtifact','Write-ADOError','Write-ADOUploadFile','Write-ADOWarning')
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = '*'

--- a/AzureDevOpsLogging/Public/Set-ADOVariable.ps1
+++ b/AzureDevOpsLogging/Public/Set-ADOVariable.ps1
@@ -1,0 +1,58 @@
+<#
+.SYNOPSIS
+Sets a variable in the variable service of taskcontext. The first task can set a variable, and following tasks are able to use the variable. The variable is exposed to the following tasks as an environment variable.
+
+.DESCRIPTION
+Sets a variable in the variable service of taskcontext. The first task can set a variable, and following tasks are able to use the variable. The variable is exposed to the following tasks as an environment variable.
+
+.PARAMETER Name
+The name of the variable
+
+.PARAMETER Value
+The value of the variable
+
+.PARAMETER IsSecret
+When issecret is set to true, the value of the variable will be saved as secret and masked out from log. Secret variables aren't passed into tasks as environment variables and must instead be passed as inputs.
+
+.PARAMETER IsOutput
+When isoutput is set to true the syntax to reference the set variable varies based on whether you are accessing that variable in the same job, a future job, or a future stage. Additionally, if isoutput is set to false the syntax for using that variable within the same job is distinct.
+
+.PARAMETER IsReadOnly
+When isreadonly is set to true, the variable cannot be changed by subsequent steps in the same job.
+
+.EXAMPLE
+Set-ADOVariable MyVar MyValue
+
+.EXAMPLE
+Set-ADOVariable MyVar MyValue -IsSecret
+
+.EXAMPLE
+Set-ADOVariable MyVar MyValue -IsOutput -IsReadOnly
+#>
+function Set-ADOVariable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $Name,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string] $Value,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $IsSecret,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $IsOutput,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $IsReadOnly
+    )
+
+    $properties = New-Object System.Collections.ArrayList
+    $properties.Add("variable=$Name") | Out-Null
+    if($IsSecret.IsPresent) { $properties.Add("issecret=true") | Out-Null }
+    if($IsOutput.IsPresent) { $properties.Add("isoutput=true") | Out-Null }
+    if($IsReadOnly.IsPresent) { $properties.Add("isreadonly=true") | Out-Null }
+    
+    Write-Host "##vso[task.setvariable $($properties -join ";")]$Value"
+}

--- a/AzureDevOpsLogging/Public/Write-ADOArtifact.ps1
+++ b/AzureDevOpsLogging/Public/Write-ADOArtifact.ps1
@@ -1,0 +1,43 @@
+<#
+.SYNOPSIS
+Upload a local file into a file container folder, and optionally publish an artifact as artifactname.
+
+.DESCRIPTION
+Upload a local file into a file container folder, and optionally publish an artifact as artifactname.
+
+.PARAMETER Path
+Path of the file to upload as an artifact
+
+.PARAMETER ContainerFolder
+The container in the artifact to upload the file to
+
+.PARAMETER ArtifactName
+The name of the artifact
+
+.EXAMPLE
+Write-ADOArtifact MyArtifact "C:\path\to\file.ps1"
+#>
+function Write-ADOArtifact {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $ArtifactName,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string] $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string] $ContainerFolder
+    )
+
+    $properties = New-Object System.Collections.ArrayList
+    if($ContainerFolder) { $properties.Add("containerfolder=$ContainerFolder") | Out-Null }
+    if($ArtifactName) { $properties.Add("artifactname=$ArtifactName") | Out-Null }
+    
+    $FullPath = Resolve-Path $Path -ErrorAction SilentlyContinue
+    if($FullPath) {
+        Write-Host "##vso[artifact.upload $($properties -join ";")]$FullPath"
+    } else {
+        Write-Error "Path not found: $Path"
+    }
+}

--- a/AzureDevOpsLogging/Public/Write-ADOUploadFile.ps1
+++ b/AzureDevOpsLogging/Public/Write-ADOUploadFile.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+Upload user interested file as additional log information to the current timeline record. The file shall be available for download along with task logs.
+
+.DESCRIPTION
+Upload user interested file as additional log information to the current timeline record. The file shall be available for download along with task logs.
+
+.PARAMETER Path
+Path of the file to upload
+
+.EXAMPLE
+Write-ADOUploadFile "C:\path\to\file.ps1"
+#>
+function Write-ADOUploadFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $Path
+    )
+
+    $FullPath = Resolve-Path $Path -ErrorAction SilentlyContinue
+    if($FullPath) {
+        Write-Host "##vso[task.uploadfile]$FullPath"
+    } else {
+        Write-Error "Path not found: $Path"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,146 @@ A module for logging in Azure DevOps Pipelines
 | Company name | Good Workaround |
 | PowerShell version | 5.1 |
 
+## Set-ADOVariable
+
+### SYNOPSIS
+Sets a variable in the variable service of taskcontext.
+The first task can set a variable, and following tasks are able to use the variable.
+The variable is exposed to the following tasks as an environment variable.
+
+### SYNTAX
+
+```
+Set-ADOVariable [-Name] <String> [-Value] <String> [-IsSecret] [-IsOutput] [-IsReadOnly]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### DESCRIPTION
+Sets a variable in the variable service of taskcontext.
+The first task can set a variable, and following tasks are able to use the variable.
+The variable is exposed to the following tasks as an environment variable.
+
+### EXAMPLES
+
+#### EXAMPLE 1
+```
+Set-ADOVariable MyVar MyValue
+```
+
+#### EXAMPLE 2
+```
+Set-ADOVariable MyVar MyValue -IsSecret
+```
+
+#### EXAMPLE 3
+```
+Set-ADOVariable MyVar MyValue -IsOutput -IsReadOnly
+```
+
+### PARAMETERS
+
+#### -Name
+The name of the variable
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -Value
+The value of the variable
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -IsSecret
+When issecret is set to true, the value of the variable will be saved as secret and masked out from log.
+Secret variables aren't passed into tasks as environment variables and must instead be passed as inputs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -IsOutput
+When isoutput is set to true the syntax to reference the set variable varies based on whether you are accessing that variable in the same job, a future job, or a future stage.
+Additionally, if isoutput is set to false the syntax for using that variable within the same job is distinct.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -IsReadOnly
+When isreadonly is set to true, the variable cannot be changed by subsequent steps in the same job.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -ProgressAction
+
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+### INPUTS
+
+### OUTPUTS
+
+### NOTES
+
+### RELATED LINKS
 ## Start-ADOGroup
 
 ### SYNOPSIS
@@ -94,6 +234,100 @@ Stop-ADOGroup
 ```
 
 ### PARAMETERS
+
+#### -ProgressAction
+
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+### INPUTS
+
+### OUTPUTS
+
+### NOTES
+
+### RELATED LINKS
+## Write-ADOArtifact
+
+### SYNOPSIS
+Upload a local file into a file container folder, and optionally publish an artifact as artifactname.
+
+### SYNTAX
+
+```
+Write-ADOArtifact [-ArtifactName] <String> [-Path] <String> [-ContainerFolder <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### DESCRIPTION
+Upload a local file into a file container folder, and optionally publish an artifact as artifactname.
+
+### EXAMPLES
+
+#### EXAMPLE 1
+```
+Write-ADOArtifact MyArtifact "C:\path\to\file.ps1"
+```
+
+### PARAMETERS
+
+#### -ArtifactName
+The name of the artifact
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -Path
+Path of the file to upload as an artifact
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -ContainerFolder
+The container in the artifact to upload the file to
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 #### -ProgressAction
 
@@ -219,6 +453,71 @@ Aliases:
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### -ProgressAction
+
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+#### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+### INPUTS
+
+### OUTPUTS
+
+### NOTES
+
+### RELATED LINKS
+## Write-ADOUploadFile
+
+### SYNOPSIS
+Upload user interested file as additional log information to the current timeline record.
+The file shall be available for download along with task logs.
+
+### SYNTAX
+
+```
+Write-ADOUploadFile [-Path] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### DESCRIPTION
+Upload user interested file as additional log information to the current timeline record.
+The file shall be available for download along with task logs.
+
+### EXAMPLES
+
+#### EXAMPLE 1
+```
+Write-ADOUploadFile "C:\path\to\file.ps1"
+```
+
+### PARAMETERS
+
+#### -Path
+Path of the file to upload
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
This commit adds a new cmdlet called Write-ADOArtifact to the AzureDevOpsLogging module. The cmdlet allows users to upload a local file into a file container folder in Azure DevOps artifacts and optionally publish it as an artifact. This functionality is useful for automating the process of uploading files as part of a CI/CD pipeline.

Signed-off-by: Marius Solbakken Mellum <marius.solbakken@fortytwo.io>