### PR TITLE
fix: Do not put anything into $Error when Private folder does not exist

### DIFF
--- a/AzureDevOpsLogging/AzureDevOpsLogging.psm1
+++ b/AzureDevOpsLogging/AzureDevOpsLogging.psm1
@@ -1,5 +1,5 @@
 # Get public and private function definition files.
-$Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
+$Private = (Test-Path "$PSScriptRoot\Private") ? @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue ) : @()
 $Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
 
 # Dot source the files in order to define all cmdlets


### PR DESCRIPTION
Signed-off-by: Marius Solbakken Mellum <marius.solbakken@fortytwo.io>